### PR TITLE
Factory: add corem types to match other contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,6 +450,8 @@ name = "dex-factory"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bindings-test",
+ "coreum-wasm-sdk",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cw-multi-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/WHELP-project/whelp-contracts"
 
 [workspace.dependencies]
 anyhow = "1"
+bindings-test = { path = "./packages/bindings-test" }
 cw20-base = { version = "1.1", package = "cw20-base", features = ["library"] }
 coreum-wasm-sdk = "0.1.1"
 cosmwasm-schema = "1.4"

--- a/contracts/factory/Cargo.toml
+++ b/contracts/factory/Cargo.toml
@@ -14,6 +14,7 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
+coreum-wasm-sdk = { workspace = true }
 cosmwasm-schema = { workspace = true }
 cosmwasm-std = { workspace = true }
 cw-storage-plus = { workspace = true }
@@ -27,6 +28,7 @@ itertools = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+bindings-test = { workspace = true }
 cw-multi-test = { workspace = true }
 cw20-base = { workspace = true }
 # dex-factory = { workspace = true }

--- a/contracts/factory/src/contract.rs
+++ b/contracts/factory/src/contract.rs
@@ -1,6 +1,7 @@
+use coreum_wasm_sdk::core::{CoreumMsg, CoreumQueries};
 use cosmwasm_std::{
     attr, entry_point, from_json, to_json_binary, Addr, Binary, CosmosMsg, Decimal, Deps, DepsMut,
-    Env, MessageInfo, Order, Reply, ReplyOn, Response, StdError, StdResult, SubMsg, WasmMsg,
+    Env, MessageInfo, Order, Reply, ReplyOn, StdError, StdResult, WasmMsg,
 };
 use cw2::set_contract_version;
 use cw20::Cw20ReceiveMsg;
@@ -33,6 +34,9 @@ use crate::{
 use itertools::Itertools;
 use std::collections::HashSet;
 
+pub type Response = cosmwasm_std::Response<CoreumMsg>;
+pub type SubMsg = cosmwasm_std::SubMsg<CoreumMsg>;
+
 /// Contract name that is used for migration.
 const CONTRACT_NAME: &str = "dex-factory";
 /// Contract version that is used for migration.
@@ -49,7 +53,7 @@ const MAX_TRADING_STARTS_DELAY: u64 = 60 * SECONDS_PER_DAY;
 /// * **msg**  is message which contains the parameters used for creating the contract.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     env: Env,
     _info: MessageInfo,
     msg: InstantiateMsg,
@@ -139,7 +143,7 @@ pub struct UpdateConfig {
 /// * **ExecuteMsg::MarkAsMigrated {}** Mark pairs as migrated.
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn execute(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     env: Env,
     info: MessageInfo,
     msg: ExecuteMsg,
@@ -252,7 +256,7 @@ pub fn execute(
 }
 
 fn receive_cw20_message(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     env: Env,
     info: MessageInfo,
     msg: Cw20ReceiveMsg,
@@ -314,7 +318,7 @@ fn receive_cw20_message(
 }
 
 fn execute_update_pair_fees(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     asset_infos: Vec<AssetInfo>,
     fee_config: FeeConfig,
@@ -352,7 +356,7 @@ fn execute_update_pair_fees(
 /// ## Executor
 /// Only the owner can execute this.
 fn execute_create_distribution_flow(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     env: Env,
     info: MessageInfo,
     asset_infos: Vec<AssetInfo>,
@@ -387,7 +391,7 @@ fn execute_create_distribution_flow(
 /// ## Executor
 /// Only the owner can execute this.
 pub fn execute_update_config(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     param: UpdateConfig,
 ) -> Result<Response, ContractError> {
@@ -423,7 +427,7 @@ pub fn execute_update_config(
 /// ## Executor
 /// Only the owner can execute this.
 pub fn execute_update_pair_config(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     pair_config: PoolConfig,
 ) -> Result<Response, ContractError> {
@@ -461,7 +465,7 @@ pub fn execute_update_pair_config(
 /// * **distribution_flows** is a vector of distribution flows to be created for the pair's staking contract.
 #[allow(clippy::too_many_arguments)]
 pub fn execute_create_pair(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     env: Env,
     pool_type: PoolType,
@@ -549,7 +553,7 @@ pub fn execute_create_pair(
 ///
 /// * **pairs** is a vector of pairs which should be marked as transferred.
 fn execute_mark_pairs_as_migrated(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     pairs: Vec<String>,
 ) -> Result<Response, ContractError> {
@@ -573,7 +577,11 @@ fn execute_mark_pairs_as_migrated(
 
 /// The entry point to the contract for processing replies from submessages.
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn reply(deps: DepsMut, env: Env, msg: Reply) -> Result<Response, ContractError> {
+pub fn reply(
+    deps: DepsMut<CoreumQueries>,
+    env: Env,
+    msg: Reply,
+) -> Result<Response, ContractError> {
     // parse the reply
     let res = cw_utils::parse_reply_instantiate_data(msg).map_err(|_| {
         StdError::parse_err("MsgInstantiateContractResponse", "failed to parse data")
@@ -591,7 +599,7 @@ pub mod reply {
     use super::*;
 
     pub fn instantiate_pair(
-        deps: DepsMut,
+        deps: DepsMut<CoreumQueries>,
         env: Env,
         res: MsgInstantiateContractResponse,
     ) -> Result<Response, ContractError> {
@@ -658,7 +666,7 @@ pub mod reply {
 /// ## Executor
 /// Only the owner can execute this.
 pub fn deregister_pool_and_staking(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     asset_infos: Vec<AssetInfo>,
 ) -> Result<Response, ContractError> {
@@ -721,7 +729,7 @@ pub fn deregister_pool_and_staking(
 ///
 /// * **QueryMsg::PoolsToMigrate {}** Returns a vector that contains pair addresses that are not migrated.
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
+pub fn query(deps: Deps<CoreumQueries>, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
     match msg {
         QueryMsg::Config {} => to_json_binary(&query_config(deps)?),
         QueryMsg::Pool { asset_infos } => to_json_binary(&query_pair(deps, asset_infos)?),
@@ -740,7 +748,7 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 }
 
 /// Returns a vector that contains blacklisted pair types
-pub fn query_blacklisted_pool_types(deps: Deps) -> StdResult<Vec<PoolType>> {
+pub fn query_blacklisted_pool_types(deps: Deps<CoreumQueries>) -> StdResult<Vec<PoolType>> {
     PAIR_CONFIGS
         .range(deps.storage, None, None, Order::Ascending)
         .filter_map(|result| match result {
@@ -757,7 +765,7 @@ pub fn query_blacklisted_pool_types(deps: Deps) -> StdResult<Vec<PoolType>> {
 }
 
 /// Returns general contract parameters using a custom [`ConfigResponse`] structure.
-pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
+pub fn query_config(deps: Deps<CoreumQueries>) -> StdResult<ConfigResponse> {
     let config = CONFIG.load(deps.storage)?;
     let resp = ConfigResponse {
         owner: config.owner,
@@ -776,7 +784,7 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
 
 /// Returns a pair's data using the assets in `asset_infos` as input (those being the assets that are traded in the pair).
 /// * **asset_infos** is a vector with assets traded in the pair.
-pub fn query_pair(deps: Deps, asset_infos: Vec<AssetInfo>) -> StdResult<PairInfo> {
+pub fn query_pair(deps: Deps<CoreumQueries>, asset_infos: Vec<AssetInfo>) -> StdResult<PairInfo> {
     let asset_infos = asset_infos
         .into_iter()
         .map(|a| a.validate(deps.api))
@@ -791,7 +799,7 @@ pub fn query_pair(deps: Deps, asset_infos: Vec<AssetInfo>) -> StdResult<PairInfo
 ///
 /// * **limit** sets the number of pairs to be retrieved.
 pub fn query_pairs(
-    deps: Deps,
+    deps: Deps<CoreumQueries>,
     start_after: Option<Vec<AssetInfo>>,
     limit: Option<u32>,
 ) -> StdResult<PoolsResponse> {
@@ -805,7 +813,10 @@ pub fn query_pairs(
 
 /// Returns the fee setup for a specific pair type using a [`FeeInfoResponse`] struct.
 /// * **pool_type** is a struct that represents the fee information (total and protocol fees) for a specific pair type.
-pub fn query_fee_info(deps: Deps, pool_type: PoolType) -> StdResult<FeeInfoResponse> {
+pub fn query_fee_info(
+    deps: Deps<CoreumQueries>,
+    pool_type: PoolType,
+) -> StdResult<FeeInfoResponse> {
     let config = CONFIG.load(deps.storage)?;
     let pair_config = PAIR_CONFIGS.load(deps.storage, pool_type.to_string())?;
 
@@ -818,7 +829,11 @@ pub fn query_fee_info(deps: Deps, pool_type: PoolType) -> StdResult<FeeInfoRespo
 
 /// Manages the contract migration.
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, ContractError> {
+pub fn migrate(
+    deps: DepsMut<CoreumQueries>,
+    _env: Env,
+    msg: MigrateMsg,
+) -> Result<Response, ContractError> {
     match msg {
         MigrateMsg::Update() => {
             ensure_from_older_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;

--- a/contracts/factory/src/mock_querier.rs
+++ b/contracts/factory/src/mock_querier.rs
@@ -1,3 +1,4 @@
+use coreum_wasm_sdk::core::CoreumQueries;
 use cosmwasm_std::{
     from_json,
     testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR},
@@ -7,13 +8,13 @@ use cosmwasm_std::{
 
 use dex::pool::{PairInfo, QueryMsg};
 
-use std::collections::HashMap;
+use std::{collections::HashMap, marker::PhantomData};
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies.
-/// This uses the Coreum CustomQuerier.
+/// This uses the Dex CustomQuerier.
 pub fn mock_dependencies(
     contract_balance: &[Coin],
-) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier> {
+) -> OwnedDeps<MockStorage, MockApi, WasmMockQuerier, CoreumQueries> {
     let custom_querier: WasmMockQuerier =
         WasmMockQuerier::new(MockQuerier::new(&[(MOCK_CONTRACT_ADDR, contract_balance)]));
 
@@ -21,7 +22,7 @@ pub fn mock_dependencies(
         storage: MockStorage::default(),
         api: MockApi::default(),
         querier: custom_querier,
-        custom_query_type: Default::default(),
+        custom_query_type: PhantomData,
     }
 }
 

--- a/contracts/factory/src/querier.rs
+++ b/contracts/factory/src/querier.rs
@@ -1,11 +1,13 @@
+use coreum_wasm_sdk::core::CoreumQueries;
 use cosmwasm_std::{QuerierWrapper, StdResult};
+
 use dex::pool::{PairInfo, QueryMsg};
 
 /// Returns information about a pair (using the [`PoolInfo`] struct).
 ///
 /// `pool_contract` is the pool for which to retrieve information.
 pub fn query_pair_info(
-    querier: &QuerierWrapper,
+    querier: &QuerierWrapper<CoreumQueries>,
     pool_contract: impl Into<String>,
 ) -> StdResult<PairInfo> {
     querier.query_wasm_smart(pool_contract, &QueryMsg::Pair {})

--- a/contracts/factory/src/state.rs
+++ b/contracts/factory/src/state.rs
@@ -1,7 +1,7 @@
+use coreum_wasm_sdk::core::CoreumQueries;
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{Addr, Api, Decimal, Deps, Order, StdResult};
 use cw_storage_plus::{Bound, Item, Map};
-use itertools::Itertools;
 
 use crate::error::ContractError;
 use dex::{
@@ -9,6 +9,8 @@ use dex::{
     common::OwnershipProposal,
     factory::{DefaultStakeConfig, DistributionFlow, PoolConfig},
 };
+
+use itertools::Itertools;
 
 /// This structure holds the main contract parameters.
 #[cw_serde]
@@ -78,7 +80,7 @@ const DEFAULT_LIMIT: u32 = 10;
 ///
 /// `limit` is the number of items to retrieve.
 pub fn read_pairs(
-    deps: Deps,
+    deps: Deps<CoreumQueries>,
     start_after: Option<Vec<AssetInfo>>,
     limit: Option<u32>,
 ) -> StdResult<Vec<Addr>> {

--- a/packages/dex/src/common.rs
+++ b/packages/dex/src/common.rs
@@ -1,7 +1,7 @@
+use coreum_wasm_sdk::core::{CoreumMsg, CoreumQueries};
 use cosmwasm_schema::cw_serde;
 use cosmwasm_std::{attr, Addr, Api, DepsMut, Env, MessageInfo, StdError, StdResult};
 use cw_storage_plus::Item;
-use coreum_wasm_sdk::core::{CoreumQueries, CoreumMsg};
 
 pub type Response = cosmwasm_std::Response<CoreumMsg>;
 

--- a/packages/dex/src/common.rs
+++ b/packages/dex/src/common.rs
@@ -1,6 +1,9 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{attr, Addr, Api, DepsMut, Env, MessageInfo, Response, StdError, StdResult};
+use cosmwasm_std::{attr, Addr, Api, DepsMut, Env, MessageInfo, StdError, StdResult};
 use cw_storage_plus::Item;
+use coreum_wasm_sdk::core::{CoreumQueries, CoreumMsg};
+
+pub type Response = cosmwasm_std::Response<CoreumMsg>;
 
 const MAX_PROPOSAL_TTL: u64 = 1209600;
 
@@ -24,7 +27,7 @@ pub struct OwnershipProposal {
 /// ## Executor
 /// Only the current contract owner can execute this.
 pub fn propose_new_owner(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     env: Env,
     new_owner: String,
@@ -71,7 +74,7 @@ pub fn propose_new_owner(
 /// ## Executor
 /// Only the current owner can execute this.
 pub fn drop_ownership_proposal(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     owner: Addr,
     proposal: Item<OwnershipProposal>,
@@ -93,11 +96,11 @@ pub fn drop_ownership_proposal(
 /// ## Executor
 /// Only the newly proposed owner can execute this.
 pub fn claim_ownership(
-    deps: DepsMut,
+    deps: DepsMut<CoreumQueries>,
     info: MessageInfo,
     env: Env,
     proposal: Item<OwnershipProposal>,
-    cb: fn(DepsMut, Addr) -> StdResult<()>,
+    cb: fn(DepsMut<CoreumQueries>, Addr) -> StdResult<()>,
 ) -> StdResult<Response> {
     let p = proposal
         .load(deps.storage)


### PR DESCRIPTION
They weren't necessary, but since I'm introducing a multitest cross contract calls in the staking then I need to have all types to match.